### PR TITLE
feat: add allowEmptyFile flag to emit output file even if it's empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "mini-css-extract-plugin",
-  "version": "0.4.2",
+  "name": "@randomjs/mini-css-extract-plugin",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mini-css-extract-plugin",
-  "version": "0.4.2",
+  "name": "@randomjs/mini-css-extract-plugin",
+  "version": "0.5.0",
   "description": "extracts CSS into separate files",
   "license": "MIT",
   "repository": "webpack-contrib/mini-css-extract-plugin",

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,10 @@ import webpack from 'webpack';
 import sources from 'webpack-sources';
 
 const { ConcatSource, SourceMapSource, OriginalSource } = sources;
-const { Template, util: { createHash } } = webpack;
+const {
+  Template,
+  util: { createHash },
+} = webpack;
 
 const NS = path.dirname(fs.realpathSync(__filename));
 
@@ -97,7 +100,12 @@ class CssModule extends webpack.Module {
 }
 
 class CssModuleFactory {
-  create({ dependencies: [dependency] }, callback) {
+  create(
+    {
+      dependencies: [dependency],
+    },
+    callback
+  ) {
     callback(null, new CssModule(dependency));
   }
 }
@@ -163,7 +171,7 @@ class MiniCssExtractPlugin {
           const renderedModules = Array.from(chunk.modulesIterable).filter(
             (module) => module.type === NS
           );
-          if (renderedModules.length > 0) {
+          if (renderedModules.length > 0 || this.options.allowEmptyFile) {
             result.push({
               render: () =>
                 this.renderContentAsset(


### PR DESCRIPTION
When using style-loader in development instead of mini-css-extract,
plugin produces no output, since all css is handled by style-loader.
Http server respond with "404 not found" on .css file request. This flag
forces plugin to emit resulting css file even if it is empty.